### PR TITLE
Consumer Configuration(2) - Retry & Dead Letter Topic (DLT)

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,3 +122,4 @@
 - [[Kafka] Producer Configurations(2) ‐ Acks & Minimum In‐Sync Replicas](https://github.com/yurim0628/off-coupon/wiki/%5Bkafka%5D-Kafka-Producer-Configurations(2)-%E2%80%90-Acks-&-Minimum-In%E2%80%90Sync-Replicas)
 - [[Kafka] Producer Configurations(3) - Idempotence](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Producer-Configurations(3)-%E2%80%90-Idempotence)
 - [[Kafka] Consumer Configurations(1) - Offset Commit Strategy](https://github.com/yurim0628/off-coupon/wiki/%5BKafka%5D-Consumer-Configurations(1)-%E2%80%90-Offset-Commit-Strategy)
+- [[Kafka] Consumer Configurations(2) - Retry & DLT](https://github.com/yurim0628/time-attack-coupon-event/wiki/%5BKafka%5D-Consumer-Configurations(2)-%E2%80%90-Retry-&-Dead-Letter-Topic(DLT))

--- a/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaConsumerConfig.java
@@ -1,6 +1,9 @@
 package org.example.couponkafka.config;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.example.couponkafka.domain.CouponIssue;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
@@ -8,13 +11,19 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.annotation.EnableKafka;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
 import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.apache.kafka.clients.consumer.ConsumerConfig.*;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
 import static org.springframework.kafka.listener.ContainerProperties.AckMode.MANUAL_IMMEDIATE;
 import static org.springframework.kafka.support.serializer.ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS;
 import static org.springframework.kafka.support.serializer.ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS;
@@ -42,7 +51,8 @@ public class KafkaConsumerConfig {
     @Bean
     public DefaultKafkaConsumerFactory<String, CouponIssue> consumerFactory() {
         Map<String, Object> consumerConfig = new HashMap<>();
-        consumerConfig.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+
+        consumerConfig.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         consumerConfig.put(GROUP_ID_CONFIG, consumerGroupId);
 
         consumerConfig.put(KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
@@ -68,5 +78,21 @@ public class KafkaConsumerConfig {
         factory.getContainerProperties().setAckMode(MANUAL_IMMEDIATE);
         factory.setConsumerFactory(consumerFactory());
         return factory;
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> producerConfig = new HashMap<>();
+
+        producerConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        producerConfig.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        producerConfig.put(VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+
+        return new DefaultKafkaProducerFactory<>(producerConfig);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaRetryConfig.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaRetryConfig.java
@@ -1,0 +1,30 @@
+package org.example.couponkafka.config;
+
+import org.example.couponkafka.domain.CouponIssue;
+import org.example.couponkafka.service.DltMessageHandler;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
+import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
+import org.springframework.kafka.support.EndpointHandlerMethod;
+
+@Configuration
+public class KafkaRetryConfig {
+
+    private static final long FIXED_BACKOFF_INTERVAL_MS = 1000L;
+    private static final int MAX_RETRY_ATTEMPTS = 3;
+
+    @Bean
+    public RetryTopicConfiguration retryTopicConfiguration(KafkaTemplate<String, CouponIssue> kafkaTemplate) {
+        return RetryTopicConfigurationBuilder
+                .newInstance()
+                .fixedBackOff(FIXED_BACKOFF_INTERVAL_MS)
+                .maxAttempts(MAX_RETRY_ATTEMPTS)
+                .dltHandlerMethod(new EndpointHandlerMethod(
+                        DltMessageHandler.class,
+                        "handleDltMessage"
+                ))
+                .create(kafkaTemplate);
+    }
+}

--- a/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaRetryConfig.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/config/KafkaRetryConfig.java
@@ -1,6 +1,5 @@
 package org.example.couponkafka.config;
 
-import org.example.couponkafka.domain.CouponIssue;
 import org.example.couponkafka.service.DltMessageHandler;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -9,22 +8,17 @@ import org.springframework.kafka.retrytopic.RetryTopicConfiguration;
 import org.springframework.kafka.retrytopic.RetryTopicConfigurationBuilder;
 import org.springframework.kafka.support.EndpointHandlerMethod;
 
+import static org.springframework.kafka.retrytopic.TopicSuffixingStrategy.SUFFIX_WITH_INDEX_VALUE;
+
 @Configuration
 public class KafkaRetryConfig {
 
-    private static final long FIXED_BACKOFF_INTERVAL_MS = 1000L;
-    private static final int MAX_RETRY_ATTEMPTS = 3;
-
     @Bean
-    public RetryTopicConfiguration retryTopicConfiguration(KafkaTemplate<String, CouponIssue> kafkaTemplate) {
+    public RetryTopicConfiguration retryTopicConfig(KafkaTemplate<String, Object> kafkaTemplate) {
         return RetryTopicConfigurationBuilder
                 .newInstance()
-                .fixedBackOff(FIXED_BACKOFF_INTERVAL_MS)
-                .maxAttempts(MAX_RETRY_ATTEMPTS)
-                .dltHandlerMethod(new EndpointHandlerMethod(
-                        DltMessageHandler.class,
-                        "handleDltMessage"
-                ))
+                .setTopicSuffixingStrategy(SUFFIX_WITH_INDEX_VALUE)
+                .dltHandlerMethod(new EndpointHandlerMethod(DltMessageHandler.class, "handleDltMessage"))
                 .create(kafkaTemplate);
     }
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/domain/CouponIssue.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/domain/CouponIssue.java
@@ -3,9 +3,11 @@ package org.example.couponkafka.domain;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Getter
 @NoArgsConstructor
+@ToString(exclude = {"id", "couponStatus"})
 public class CouponIssue {
 
     private Long id;

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
@@ -24,8 +24,7 @@ public class CouponIssueConsumer {
             saveCouponIssue(couponIssue);
             acknowledgment.acknowledge();
         } catch (Exception e) {
-            log.error("Failed to Save CouponIssue: [{}]", couponIssue, e);
-            throw new RuntimeException("Message Processing Failed", e);
+            throw new RuntimeException("Failed to Save CouponIssue. User ID: " + couponIssue.getUserId(), e);
         }
     }
 

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/CouponIssueConsumer.java
@@ -1,12 +1,14 @@
 package org.example.couponkafka.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.example.couponkafka.domain.CouponIssue;
 import org.example.couponkafka.service.port.CouponIssueRepository;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class CouponIssueConsumer {
@@ -18,8 +20,13 @@ public class CouponIssueConsumer {
             groupId = "Coupon-TimeAttackCouponIssue"
     )
     public void listener(CouponIssue couponIssue, Acknowledgment acknowledgment) {
-        saveCouponIssue(couponIssue);
-        acknowledgment.acknowledge();
+        try {
+            saveCouponIssue(couponIssue);
+            acknowledgment.acknowledge();
+        } catch (Exception e) {
+            log.error("Failed to Save CouponIssue: [{}]", couponIssue, e);
+            throw new RuntimeException("Message Processing Failed", e);
+        }
     }
 
     private void saveCouponIssue(CouponIssue couponIssue) {

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/DltMessageHandler.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/DltMessageHandler.java
@@ -1,29 +1,22 @@
 package org.example.couponkafka.service;
 
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.example.couponkafka.domain.CouponIssue;
 import org.springframework.kafka.core.KafkaTemplate;
-import org.springframework.messaging.handler.annotation.Header;
-import org.springframework.stereotype.Service;
+import org.springframework.stereotype.Component;
 
-import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_TOPIC;
-
-@Service
 @Slf4j
+@Component
+@RequiredArgsConstructor
 public class DltMessageHandler {
 
-    private static final String ORIGINAL_TOPIC = "TimeAttackCouponIssue";
-    private final KafkaTemplate<String, CouponIssue> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
-    public DltMessageHandler(KafkaTemplate<String, CouponIssue> kafkaTemplate) {
-        this.kafkaTemplate = kafkaTemplate;
-    }
-
-    public void handleDltMessage(ConsumerRecord<String, CouponIssue> record,
-                                 @Header(RECEIVED_TOPIC) String topic) {
-        log.error("Received Message in DLT. Topic: [{}], Value: [{}]", topic, record.value());
-        kafkaTemplate.send(ORIGINAL_TOPIC, record.key(), record.value());
-        log.info("Message Successfully Reprocessed. Value: [{}]", record.value());
+    public void handleDltMessage(ConsumerRecord<String, CouponIssue> record) {
+        log.info("Starting DLT Message Processing. Consumer Record: [{}]", record);
+        kafkaTemplate.send("TimeAttackCouponIssue", record.value());
+        log.info("Completed DLT Message Processing. CouponIssue Sent: [{}]", record.value());
     }
 }

--- a/coupon-kafka/src/main/java/org/example/couponkafka/service/DltMessageHandler.java
+++ b/coupon-kafka/src/main/java/org/example/couponkafka/service/DltMessageHandler.java
@@ -1,0 +1,29 @@
+package org.example.couponkafka.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.example.couponkafka.domain.CouponIssue;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.messaging.handler.annotation.Header;
+import org.springframework.stereotype.Service;
+
+import static org.springframework.kafka.support.KafkaHeaders.RECEIVED_TOPIC;
+
+@Service
+@Slf4j
+public class DltMessageHandler {
+
+    private static final String ORIGINAL_TOPIC = "TimeAttackCouponIssue";
+    private final KafkaTemplate<String, CouponIssue> kafkaTemplate;
+
+    public DltMessageHandler(KafkaTemplate<String, CouponIssue> kafkaTemplate) {
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public void handleDltMessage(ConsumerRecord<String, CouponIssue> record,
+                                 @Header(RECEIVED_TOPIC) String topic) {
+        log.error("Received Message in DLT. Topic: [{}], Value: [{}]", topic, record.value());
+        kafkaTemplate.send(ORIGINAL_TOPIC, record.key(), record.value());
+        log.info("Message Successfully Reprocessed. Value: [{}]", record.value());
+    }
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 
@@ -38,6 +39,7 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 
@@ -53,6 +55,7 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9094
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
+      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
-      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 
@@ -39,7 +38,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
-      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 
@@ -55,7 +53,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9094
       KAFKA_DEFAULT_REPLICATION_FACTOR: 3
       KAFKA_MIN_INSYNC_REPLICAS: 2
-      KAFKA_CREATE_TOPICS: "TimeAttackCouponIssue.DLT:1:3"
     networks:
       - off-coupon-network
 


### PR DESCRIPTION
### **개요**
Kafka Consumer에 Retry 및 Dead Letter Queue(DLQ) 기능을 추가하여 메시지 처리 실패 시 재시도 및 실패 메시지 관리 기능을 구현

### **주요 변경사항**

1. **Retry 및 DLQ 설정**
   - `RetryTopicConfiguration`을 통해 재시도 토픽 생성 및 고정 백오프 정책 설정.
   - 최대 재시도 횟수를 초과한 메시지를 DLQ로 전송.

2. **DLQ 메시지 처리기 구현**
   - `DltMessageHandler`를 통해 DLQ로 전송된 메시지를 원본 토픽으로 재전송하는 기능 추가.

3. **문서화**
   - README 및 Wiki에 Retry 및 DLQ 설정과 사용법 업데이트.

### **테스트 체크리스트**
- [x] 메시지가 재시도 후 DLQ로 전송되는지 확인.
- [x] DLQ에서 메시지가 원본 토픽으로 재전송되는지 확인.

### **테스트 결과 요약**

1. **Retry 메커니즘**
   - 메시지가 3회 재시도 후 DLQ로 정상적으로 전송됨.
2. **DLQ 메시지 처리**
   - DLQ로 전송된 메시지가 원본 토픽으로 정상 재처리됨.
3. **안정성 강화**
   - 대량 메시지 실패 상황에서도 데이터 손실 없이 복구 가능성 확인.

